### PR TITLE
Use new Bluetooth permissions for Android 12

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,12 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="org.ecmdroid">
 
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
For issue: https://github.com/ecmdroid/ecmdroid/issues/8
Should let the app run on Android 12 devices.
See: https://developer.android.com/guide/topics/connectivity/bluetooth/permissions
I have not tested this yet.
