### PR TITLE
Bugfix for unsaved parameter on DDFI-3 + Option to fix issue 11

### DIFF
--- a/app/src/main/java/org/ecmdroid/ECM.java
+++ b/app/src/main/java/org/ecmdroid/ECM.java
@@ -528,6 +528,25 @@ public class ECM {
 		}
 	}
 
+	/**
+	 * Write specific bytes on a single page to the EEPROM
+	 *
+	 * @param page the page to write
+	 * @throws IOException if an I/O error occurs during programming
+	 */
+	public void writeEEPromPage(Page page, int offset, int length) throws IOException {
+		byte[] buffer = page.getBytes(0,page.length(), new byte[page.length()],0);
+		byte[] selectedBytes = new byte[length];
+		if(page.nr() == 0){
+			// Page 0 starts at FF (+1 to inc zero) then uses negative offset.
+			System.arraycopy(buffer, buffer.length+offset, selectedBytes, 0, length);
+			offset+=256; // Update for PDU
+		} else {
+			System.arraycopy(buffer, offset, selectedBytes, 0, length);
+		}
+		sendPDU(PDU.setRequest(page.nr(), offset, selectedBytes, 0, length));
+		page.saved();
+	}
 
 	/**
 	 * Request runtime data from the ECM

--- a/app/src/main/java/org/ecmdroid/fragments/LogFragment.java
+++ b/app/src/main/java/org/ecmdroid/fragments/LogFragment.java
@@ -72,6 +72,7 @@ public class LogFragment extends Fragment implements OnClickListener {
 	private static final String PREFS_CONVERTLOG = "convertlog";
 	private static final String PREFS_DELAY = "delay";
 	private static final String PREFS_KEEP_SCREEN_ON = "keep_screen_on";
+	private static final String PREFS_LOG_EXTENSION = "log_extension";
 	private static final String TAG = "LogFragment";
 	private Button recordButton;
 	private TextView logStatus;
@@ -239,7 +240,7 @@ public class LogFragment extends Fragment implements OnClickListener {
 
 		docRoot = DocumentFile.fromTreeUri(getContext(), Uri.parse(uri));
 		logTimestamp = DateFormat.format("yyyyMMdd_kkmmss", System.currentTimeMillis());
-		DocumentFile f = docRoot.createFile("application/x-ecmdroid-binlog", logTimestamp.toString() + ".log");
+		DocumentFile f = docRoot.createFile("application/x-ecmdroid-binlog", logTimestamp.toString() + "." + prefs.getString(PREFS_LOG_EXTENSION, "log")); // Allow .log or .bin depending on prefs choice.  Too far?
 		logFile = getContext().getContentResolver().openFileDescriptor(f.getUri(), "rw");
 		FileOutputStream out = new FileOutputStream(logFile.getFileDescriptor());
 

--- a/app/src/main/java/org/ecmdroid/task/BurnTask.java
+++ b/app/src/main/java/org/ecmdroid/task/BurnTask.java
@@ -91,8 +91,23 @@ public class BurnTask extends ProgressDialogTask {
 				int count = eeprom.getPageCount();
 				for (Page pg : ecm.getEEPROM().getPages()) {
 					if (pg.nr() == 0) {
-						// TODO: We don't handle page 0 for now...
-						count--;
+						// Added for DDFI-3 AFV Front value.
+						if (eeprom.getType() == ECM.Type.DDFI3) {
+							if (!fast_burn || pg.isTouched()) {
+								publishProgress(context.getString(R.string.burn_progress, ++i, count));
+								ecm.writeEEPromPage(pg,-22,2);
+								changes = true;
+							}
+						} else if (eeprom.getType() == ECM.Type.DDFI2) {
+							// Added to allow Baro setting on DDFI-2 Bikes with no MAP sensor. Could be used to set with phone Baro sensor in the future?
+							if (!fast_burn || pg.isTouched()) {
+								publishProgress(context.getString(R.string.burn_progress, ++i, count));
+								ecm.writeEEPromPage(pg,-2,1);
+								changes = true;
+							}
+						} else {
+							count--;
+						}
 						continue;
 					}
 					// Either write all pages (if no local modifications exist) or only the ones that are touched

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -12,4 +12,12 @@
 		<item>TCP</item>
 		<item>COM</item>
 	</array>
+	<array name="logExtensionTypes">
+		<item>.log</item>
+		<item>.bin</item>
+	</array>
+	<array name="logExtensionValues">
+		<item>log</item>
+		<item>bin</item>
+	</array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
 	<string name="prefs_conn_type">connection_type</string>
 	<string name="prefs_bt_connection">BT</string>
 	<string name="prefs_tcp_connection">TCP</string>
+	<string name="prefs_log_extension">log</string>
 	<string name="setup">ECM Parameters</string>
 	<string name="about">About</string>
 	<string name="fixed">Fixed</string>
@@ -236,6 +237,8 @@
 	<string name="the_buell_ecm_diagnostics_tool">The Buell ECM Diagnostics Tool</string>
 	<string name="keep_screen_on_summary">Keep Screen on while recording a log</string>
 	<string name="keep_screen_on_title">Keep Screen On</string>
+	<string name="log_extension_summary">File extension for binary log files</string>
+	<string name="log_extension_title">Log Extension</string>
 	<string name="ecm_version">ECM Version:</string>
 	<string name="update_db">Updating database...</string>
     <string name="pairing_request"><![CDATA[PAIRING requested\n-> Perform pairing steps. Connect again]]></string>

--- a/app/src/main/res/xml/app_prefs.xml
+++ b/app/src/main/res/xml/app_prefs.xml
@@ -8,6 +8,13 @@
 		android:singleLine="true"
 		android:title="@string/storage_location" />
 	<ListPreference
+		android:defaultValue="@string/prefs_log_extension"
+		android:entries="@array/logExtensionTypes"
+		android:entryValues="@array/logExtensionValues"
+		android:key="log_extension"
+		android:title="@string/log_extension_title"
+		android:summary="@string/log_extension_summary" />
+	<ListPreference
 		android:defaultValue="@string/prefs_bt_connection"
 		android:entries="@array/connectionTypes"
 		android:entryValues="@array/connectionValues"


### PR DESCRIPTION
Hi,

[Foxies-CSTL](https://github.com/Foxies-CSTL) had asked me a while back to look at the AFV Front setting not saving to the EEPROM correctly.  This parameter is stored on page 0 so I have added a fix for that.  I made it only save specific bytes rather than the whole page so that users don't change things that are not really parameters.  I have tested this on my DDFI-2 ECM for Barometer value and [Foxies-CSTL](https://github.com/Foxies-CSTL) has tested it on his DDFI-3 ECM for the AFV Front setting.

I also added a solution to his Issue #11 so that the user can now select what they want the binary log file extension to be rather than simply changing .log to .bin in the code as some users may have workflow that relies on one extension or the other.

Cheers