### PR TITLE
Add AGENTS.md and user/developer documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# Repository Guidelines
+
+## Project Overview
+
+EcmDroid is a native Android diagnostic and tuning app for Buell motorcycles running Zeeltronic/ecmspy-derived DDFI(-1,-2,-3) engine control modules (ECMs). It connects to the ECM over Bluetooth Classic, Bluetooth Low Energy (BLE), or USB-to-serial adapters to:
+
+- Read live runtime data (RPM, TPS, CLT, fueling, timing, etc.)
+- Read/write EEPROM configuration (calibration tables, scalars, bitfields)
+- Read current/recent/stored error codes and clear them
+- Trigger active tests (fuel pump, ignition coils, injectors, fan, exhaust valve, shift light, etc.)
+- Record binary runtime logs and convert them to MegaLogViewer (`.msl`) format
+
+License: GPL v3 (`LICENSE`). Package/applicationId: `org.ecmdroid`.
+
+## Architecture & Data Flow
+
+Legacy-style Java Android app: singleton hardware facade + background Service + fragment-based UI. No DI framework, no Room, no coroutines/RxJava — manual construction and `AsyncTask`/`Thread` throughout.
+
+**Connect → Setup EEPROM → Poll runtime data → Log / Act**
+
+1. **Connect**: `MainActivity` (`app/src/main/java/org/ecmdroid/activities/MainActivity.java`) drives device selection (paired Bluetooth, BLE, or USB via `UsbSerialPort`) and calls `ECM.connect(...)`.
+2. **`ECM`** (`app/src/main/java/org/ecmdroid/ECM.java`) is a singleton facade abstracting the transport (BluetoothSocket / BLE `SerialSocket` / USB `UsbSerialPort` / TCP fallback via `PipedStreams`) and protocol (`STOCK` vs `FACTORY_RACE`, differing PDU ECM IDs `0x42`/`0x55`). Exposes `readRTData()`, `readErrors()`, `executeActiveTest()`, `readEEPROM()`, `burnEEPROM()`.
+3. **`PDU`** (`app/src/main/java/org/ecmdroid/PDU.java`) encodes/decodes the wire protocol: SOH/EOH/SOT/EOT framing, XOR checksum, factory methods (`getRequest`, `setRequest`, `commandRequest`).
+4. **EEPROM read/write**: `FetchTask`/`BurnTask` (`app/src/main/java/org/ecmdroid/task/`, `AsyncTask` subclasses of `ProgressDialogTask`) page through EEPROM via `PDU.getRequest`/`setRequest`; `EEPROM` (`EEPROM.java`) is a paginated byte array with dirty-page tracking, so burns can be optimized to only write changed pages.
+5. **Continuous polling**: `EcmDroidService` (foreground Service) runs a `ReaderThread` that loops on `ECM.readRTData()` at a configurable interval (50–5000ms), broadcasts a `REALTIME_DATA` intent, and streams `[timestamp][ECM header][data]` records to a log file when recording.
+6. **Variable definitions & scaling**: `Variable` (`Variable.java`) models a single runtime/EEPROM parameter (type, offset, scale/translate, format, unit) and does the raw-bytes → display-value conversion (`refreshValue()`). Definitions are looked up via `VariableProvider`/`BitSetProvider` interfaces, backed by `DatabaseVariableProvider`/`DatabaseBitSetProvider`, both caching results in a `HashMap`.
+7. **Logging**: recorded binary logs can be converted to MegaLogViewer text format via `Bin2MslConverter` (`app/src/main/java/org/ecmdroid/util/`).
+
+### Bundled ECM definitions database
+
+The app ships a gzip-compressed SQLite database, `app/src/main/assets/ecmdroid.db.gz`, sourced from ecmspy.com MySQL dumps. `DBHelper` (`SQLiteOpenHelper`) extracts/decompresses it into the app's private DB directory on first launch or `DB_VERSION` bump, invoked from `EcmDroidApp.onCreate()`. Schema tables: `eeprom`, `pages`, `rtoffsets`, `eeoffsets`, `names`, `bits`. All variable/bitset/EEPROM-layout lookups (`DatabaseVariableProvider`, `DatabaseBitSetProvider`, `EEPROM.get()`) run raw SQL against this DB.
+
+Updating the bundled DB (see `README.db`): apply an ecmspy.com MySQL backup → run `scripts/mysql2sqlite.sh` (awk-based MySQL-dump → SQLite converter) → strip column comments → build the sqlite file → gzip it into `app/src/main/assets/ecmdroid.db.gz` → bump `DB_VERSION` in `DBHelper.java` so devices re-extract it.
+
+## Key Directories
+
+| Path | Purpose |
+|---|---|
+| `app/src/main/java/org/ecmdroid/` | Core domain: `ECM`, `PDU`, `Variable`, `EEPROM`, `Error`, `DBHelper`, `VariableProvider`/`BitSetProvider` + DB-backed impls, `Constants` (500+ ECM variable name constants, `DataSource` enum), `Utils`, `ColorMap`, list adapters |
+| `app/src/main/java/org/ecmdroid/activities/` | `MainActivity` (launcher, drawer nav, connection UI), `PrefsActivity` (settings), `AboutActivity` |
+| `app/src/main/java/org/ecmdroid/fragments/` | One fragment per drawer tab: `MainFragment` (info), `TroubleCodeFragment`, `ActiveTestsFragment`, `DataChannelFragment`, `SetupFragment`, `LogFragment`, `EEPROMFragment`, `TorqueValuesFragment`, `CellEditorDialogFragment` |
+| `app/src/main/java/org/ecmdroid/task/` | `AsyncTask` I/O: `ProgressDialogTask` (base, modal progress + orientation lock), `FetchTask`, `BurnTask` |
+| `app/src/main/java/org/ecmdroid/util/` | `Bin2MslConverter` (binary log → MegaLogViewer `.msl`) |
+| `app/src/main/java/de/kai_morich/simple_bluetooth_le_terminal/` | Vendored 3rd-party BLE UART abstraction (`SerialSocket`, `SerialListener`) supporting Nordic/TI/Microchip/Telit profiles |
+| `app/src/main/assets/ecmdroid.db.gz` | Bundled gzipped SQLite DB of ECM variable/EEPROM definitions |
+| `app/src/main/res/` | Layouts (`main.xml`, `log.xml`, `activity_main.xml`, …), `menu/main_drawer.xml`, `values/strings.xml`, `xml/ecm_setup.xml` (DDFI-1/2/3 variable defs), `xml/device_filter.xml` (USB VID/PID whitelist) |
+| `app/src/androidTest/java/org/ecmdroid/` | Instrumented JUnit tests + `resources/` binary fixtures (`.eeprom`, `.bin`, `.msl`) |
+| `scripts/` | `mysql2sqlite.sh` (DB conversion), `mklocalversion` (git-derived version generation) |
+| `gradle/libs.versions.toml` | Central version catalog for all Gradle deps/plugins |
+
+## Development Commands
+
+Gradle wrapper only; Gradle 9.4.1 pinned via `gradle/wrapper/gradle-wrapper.properties`.
+
+```bash
+./gradlew assembleDebug          # Build debug APK
+./gradlew assembleRelease        # Build release APK (unsigned unless keystore.properties present)
+./gradlew installDebug           # Build + install debug APK on connected device
+./gradlew clean                  # Clean build outputs
+./gradlew lint                   # Android Lint
+./gradlew test                   # JVM unit tests (none currently present, see Testing)
+./gradlew connectedAndroidTest   # Instrumented tests — REQUIRES a connected device/emulator
+```
+
+APK outputs: `app/build/outputs/apk/{debug,release}/`.
+
+Release signing is optional and file-based: create a git-ignored `keystore.properties` at repo root with `keyAlias`, `keyPassword`, `storeFile`, `storePassword`; if absent, release build is unsigned.
+
+Version string embedding: `scripts/mklocalversion` runs at build time, generating `org.ecmdroid.VCS.LOCAL_VERSION` from git (`-g<hash>` if untagged HEAD, `-dirty` if uncommitted changes). Bump the shipped version by editing `versionCode`/`versionName` in `app/build.gradle.kts`.
+
+## Code Conventions & Common Patterns
+
+- **Language**: pure Java 8 (source/target compatibility `1.8`). Gradle files use Kotlin DSL (`.kts`) but no Kotlin app code — do not introduce Kotlin without discussion.
+- **Naming**: classes PascalCase (`ECM`, `PDU`, `EEPROMFragment`); methods camelCase; constants UPPER_SNAKE_CASE; every class carries a `private static final String TAG` for `Log.d/i/w/e`.
+- **Error handling**: exceptions, not return codes — `PDU.validate()` throws `ParseException` on malformed packets; caller-level failures surface via `Toast` or `AlertDialog`.
+- **Threading**: no coroutines/RxJava/Executors. Patterns used:
+  - `AsyncTask` subclasses of `ProgressDialogTask` (`FetchTask`, `BurnTask`) for ECM I/O with a modal progress dialog and screen-orientation freeze.
+  - `EcmDroidService.ReaderThread`: plain `Thread` with `synchronized`/`wait()`/`notify()` for the continuous poll loop.
+  - UI updates communicated via `BroadcastReceiver` (`REALTIME_DATA`, `RECORDING_STARTED`/`RECORDING_STOPPED` intents), registered in `onResume()`/unregistered in `onPause()`.
+  - `MainActivity`/`LogFragment` bind to `EcmDroidService` via `ServiceConnection`.
+- **Dependency management**: no DI framework. Singletons via static `getInstance(Context)` (e.g. `ECM.getInstance(...)`); fragments reach the host via `getActivity()`.
+- **State**: `ECM` singleton holds connection/protocol/EEPROM state; `SharedPreferences` for user settings (protocol, storage location, log interval, keep-screen-on); `MainActivity` persists the active drawer fragment across rotation via `savedInstanceState`.
+- **Database access**: raw SQL via `SQLiteDatabase.rawQuery()`, never an ORM. Wrap new lookups with an in-memory `HashMap` cache like `DatabaseVariableProvider`/`DatabaseBitSetProvider` do — the DB is queried frequently during live polling.
+- **Resource naming**: layouts named after the feature (`main.xml` ↔ `MainFragment`, `log.xml` ↔ `LogFragment`); menus `*_menu.xml`/`main_drawer.xml`; drawables descriptive (`ic_connected.xml`).
+- **Vendored code**: `de.kai_morich.simple_bluetooth_le_terminal` is a third-party BLE package kept in-tree — treat as external, avoid unrelated edits.
+
+## Important Files
+
+- `app/src/main/java/org/ecmdroid/EcmDroidApp.java` — `Application` subclass; triggers DB extraction on startup.
+- `app/src/main/java/org/ecmdroid/EcmDroidService.java` — foreground Service, entry point for continuous polling/recording.
+- `app/src/main/java/org/ecmdroid/activities/MainActivity.java` — launcher `Activity`, drawer navigation host.
+- `app/src/main/java/org/ecmdroid/ECM.java`, `PDU.java` — hardware/protocol core; read these before touching comms.
+- `app/src/main/java/org/ecmdroid/DBHelper.java` — bundled-DB lifecycle; bump `DB_VERSION` when `ecmdroid.db.gz` changes.
+- `app/src/main/java/org/ecmdroid/Constants.java` — canonical ECM variable name constants and `DataSource` enum.
+- `app/src/main/AndroidManifest.xml` — component registration, permissions (`BLUETOOTH_SCAN`/`CONNECT`, `ACCESS_FINE_LOCATION`, `POST_NOTIFICATIONS`), USB intent filter.
+- `app/build.gradle.kts`, `gradle/libs.versions.toml` — module config and version catalog; edit these together when bumping deps.
+- `scripts/mklocalversion`, `scripts/mysql2sqlite.sh` — build-time version generation and DB-conversion tooling (see `README.db`).
+
+## Runtime/Tooling Preferences
+
+- Build exclusively through the Gradle wrapper (`./gradlew`, `gradlew.bat`) — do not rely on a globally installed Gradle; version is pinned (9.4.1) via `gradle/wrapper/gradle-wrapper.properties`.
+- Android Gradle Plugin 9.2.1, `compileSdk` 34, `targetSdk` 33, `minSdk` 26 (Android 8.0+).
+- No Kotlin, no Jetpack Compose, no Room, no Hilt/Dagger — keep additions consistent with the existing plain-Java/AndroidX-appcompat stack.
+- Dependency versions are centralized in `gradle/libs.versions.toml` (version catalog) — add/bump deps there, reference via `libs.*` aliases in `app/build.gradle.kts`, not hardcoded coordinates.
+- `local.properties`/`keystore.properties` are git-ignored — never commit secrets or local SDK paths.
+
+## Testing & QA
+
+- **Only instrumented tests exist**, under `app/src/androidTest/java/org/ecmdroid/` (JUnit 4 + `AndroidJUnit4` runner; Espresso dependency present but unused by current tests). There is no `app/src/test/` unit-test source set and no CI pipeline (no GitHub Actions/GitLab CI/Jenkins config) — tests run only locally/manually.
+- Files: `TestECM`, `TestPDU`, `TestBin2Msl`, `TestBitSetProvider`, `TestEEPROM`, `TestUtils`, `TestVariableProvider`. Naming convention: `Test<Component>.java`, methods prefixed `test`.
+- Fixtures live in `app/src/androidTest/resources/` (`.eeprom` dumps, `.bin` runtime logs, `.msl` reference output) — reuse existing fixtures for parser/converter tests rather than inventing new binary formats.
+- Run tests with a connected device or emulator:
+  ```bash
+  ./gradlew connectedAndroidTest
+  ./gradlew connectedDebugAndroidTest
+  ```
+- `./gradlew lint` is available for static analysis; no enforced formatter/linter config was found — match surrounding code style exactly.
+- When adding tests for new protocol/DB logic, follow the existing pattern: instrumented `Test<Component>` class under `androidTest`, using bundled `.eeprom`/`.bin` resources rather than mocks (no Robolectric/mocking framework is configured).

--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ Pairing is not required for BLE serial adapters.
 
 Also checkout [ecmsim](https://github.com/ecmdroid/ecmsim) which can
 be used for testing/debugging ecmdroid without a real ECM.
+
+## Documentation
+
+* [User Guide](docs/USER_GUIDE.md) — installing, connecting, and using every
+  screen in the app.
+* [Developer Guide](docs/DEVELOPER_GUIDE.md) — architecture, wire protocol,
+  data model, build/test instructions.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,719 @@
+# EcmDroid Developer Guide
+
+Technical/architecture reference for working on the EcmDroid codebase: a
+native Android (plain Java, no DI/Compose/coroutines) diagnostic and tuning
+app for Buell DDFI(-1,-2,-3) motorcycle ECMs.
+
+For coding-agent-oriented quick reference (conventions, command cheat sheet),
+see [`AGENTS.md`](../AGENTS.md) at the repo root — this document goes deeper
+into *why* things are built this way, the wire protocol, and the data model,
+with file/line references for the parts most people need when making changes.
+For end-user documentation, see [`USER_GUIDE.md`](USER_GUIDE.md).
+
+## Table of Contents
+
+1. [Project Layout](#1-project-layout)
+2. [Building and Running](#2-building-and-running)
+3. [High-Level Architecture](#3-high-level-architecture)
+4. [The Wire Protocol (PDU)](#4-the-wire-protocol-pdu)
+5. [Transport Layer](#5-transport-layer)
+6. [ECM: the Central Facade](#6-ecm-the-central-facade)
+7. [EEPROM / Variable / BitSet Data Model](#7-eeprom--variable--bitset-data-model)
+8. [Bundled ECM-Definitions Database](#8-bundled-ecm-definitions-database)
+9. [Background Service and Threading](#9-background-service-and-threading)
+10. [UI Layer](#10-ui-layer)
+11. [Async Task Pattern](#11-async-task-pattern)
+12. [Binary Log Format and MSL Conversion](#12-binary-log-format-and-msl-conversion)
+13. [Testing](#13-testing)
+14. [Code Conventions](#14-code-conventions)
+15. [Common Pitfalls](#15-common-pitfalls)
+
+---
+
+## 1. Project Layout
+
+```
+ecmdroid/
+├── app/
+│   ├── build.gradle.kts              # module config, versionCode/versionName, signing
+│   ├── proguard-rules.pro
+│   └── src/
+│       ├── main/
+│       │   ├── AndroidManifest.xml
+│       │   ├── assets/ecmdroid.db.gz # bundled gzip'd SQLite ECM-definitions DB
+│       │   ├── assets/about.html     # About screen content
+│       │   ├── resources/            # runtime1.tab/runtime2.tab/runtime3.tab (Bin2Msl offset tables)
+│       │   ├── res/                  # layouts, menus, xml preference trees, strings
+│       │   └── java/
+│       │       ├── org/ecmdroid/                              # core domain
+│       │       ├── org/ecmdroid/activities/                   # MainActivity, PrefsActivity, AboutActivity
+│       │       ├── org/ecmdroid/fragments/                    # one fragment per drawer screen
+│       │       ├── org/ecmdroid/task/                         # AsyncTask I/O helpers
+│       │       ├── org/ecmdroid/util/                         # Bin2MslConverter
+│       │       └── de/kai_morich/simple_bluetooth_le_terminal/ # vendored BLE UART transport
+│       └── androidTest/
+│           ├── java/org/ecmdroid/         # instrumented JUnit4 tests
+│           └── resources/                 # .eeprom/.bin/.msl fixtures used by tests
+├── gradle/libs.versions.toml          # central dependency/plugin version catalog
+├── scripts/mysql2sqlite.sh            # ecmspy.com MySQL dump → SQLite converter
+├── scripts/mklocalversion             # git-derived build version string generator
+├── README.md, README.db, CHANGES, privacy-policy.md, LICENSE
+└── docs/USER_GUIDE.md, docs/DEVELOPER_GUIDE.md   (this file)
+```
+
+## 2. Building and Running
+
+Gradle wrapper only — do not rely on a system-installed Gradle (pinned in
+`gradle/wrapper/gradle-wrapper.properties`). Android Gradle Plugin 9.2.1,
+`compileSdk 34`, `targetSdk 33`, `minSdk 26` (Android 8.0+). No Kotlin, no
+Jetpack Compose, no Room, no Hilt/Dagger — keep new code consistent with the
+existing plain-Java/AndroidX-appcompat stack.
+
+```bash
+./gradlew assembleDebug          # Build debug APK
+./gradlew assembleRelease        # Build release APK (unsigned unless keystore.properties present)
+./gradlew installDebug           # Build + install debug APK on a connected device
+./gradlew clean                  # Clean build outputs
+./gradlew lint                   # Android Lint (no enforced formatter — match surrounding style)
+./gradlew connectedAndroidTest   # Instrumented tests — REQUIRES a connected device/emulator
+```
+
+APK outputs land in `app/build/outputs/apk/{debug,release}/`.
+
+- **Signing**: create a git-ignored `keystore.properties` at repo root with
+  `keyAlias`, `keyPassword`, `storeFile`, `storePassword` (see
+  `app/build.gradle.kts`); without it, release builds are unsigned.
+- **Version string**: `scripts/mklocalversion` runs at build time and
+  generates `org.ecmdroid.VCS.LOCAL_VERSION` from git (`-g<hash>` suffix if
+  untagged HEAD, `-dirty` if the working tree has uncommitted changes). Bump
+  the shipped version by editing `versionCode`/`versionName` in
+  `app/build.gradle.kts`.
+- **Dependencies** are centralized in `gradle/libs.versions.toml`; add/bump
+  there and reference via `libs.*` aliases in `app/build.gradle.kts` — never
+  hardcode Maven coordinates directly in the module build file.
+- **Hardware-free testing**: use [ecmsim](https://github.com/ecmdroid/ecmsim)
+  (a standalone ECM protocol simulator) to exercise the app without a real
+  motorcycle.
+
+## 3. High-Level Architecture
+
+Legacy-style Android app: one singleton hardware facade (`ECM`), one
+background `Service` for continuous polling/logging, and a fragment-based UI
+hung off a single `MainActivity` navigation drawer. No dependency-injection
+framework — components reach each other via `getInstance(Context)` statics or
+`getActivity()`.
+
+```mermaid
+flowchart LR
+    subgraph UI["UI Layer (org.ecmdroid.activities / .fragments)"]
+        MA[MainActivity\ndrawer + connect UI]
+        FRAG[Fragments\nMain/Setup/EEPROM/DataChannel/\nLog/TroubleCode/ActiveTests]
+    end
+    subgraph SVC["EcmDroidService"]
+        RT[ReaderThread\npolls ECM.readRTData()]
+    end
+    subgraph CORE["Core Domain (org.ecmdroid)"]
+        ECMc[ECM\nsingleton facade]
+        PDU[PDU\nwire framing]
+        EEPROM[EEPROM / Page]
+        VAR[Variable / BitSet / Bit]
+        PROV[DatabaseVariableProvider\nDatabaseBitSetProvider]
+    end
+    subgraph DB["SQLite (ecmdroid.db, from assets/ecmdroid.db.gz)"]
+    end
+    subgraph XPORT["Transport"]
+        BT[BluetoothSocket\nClassic SPP]
+        BLE[SerialSocket\nBLE GATT]
+        USB[UsbSerialPort]
+        TCP[java.net.Socket]
+    end
+
+    MA -->|connect()| ECMc
+    FRAG -->|bindService| SVC
+    FRAG -->|read/write vars| ECMc
+    RT -->|readRTData| ECMc
+    ECMc --> PDU
+    ECMc --> EEPROM
+    ECMc --> VAR
+    VAR --> PROV
+    PROV --> DB
+    EEPROM --> DB
+    ECMc --> BT & BLE & USB & TCP
+```
+
+**Connect → Setup EEPROM → Poll runtime data → Log / Act** is the core data
+flow:
+
+1. **Connect** — `MainActivity` (`app/src/main/java/org/ecmdroid/activities/MainActivity.java`)
+   drives device selection (paired classic Bluetooth device, BLE scan result
+   via `DevicesFragment`, or a probed `UsbSerialPort`) and calls one of
+   `ECM.connect(...)`.
+2. **`ECM`** (`app/src/main/java/org/ecmdroid/ECM.java`) is a singleton
+   facade abstracting the transport (`BluetoothSocket` / BLE `SerialSocket` /
+   `UsbSerialPort` / TCP `Socket`) and the protocol variant (`STOCK` vs.
+   `FACTORY_RACE`, which changes the PDU ECM address byte between `0x42` and
+   `0x55`). It exposes `setupEEPROM()`, `readRTData()`, `getErrors()`,
+   `runTest()`, `readEEPromPage()`, `writeEEPromPage()`.
+3. **`PDU`** (`app/src/main/java/org/ecmdroid/PDU.java`) encodes/decodes the
+   wire protocol: `SOH`/`EOH`/`SOT`/`EOT` framing, XOR checksum, static
+   factories `getRequest()`/`setRequest()`/`commandRequest()`.
+4. **EEPROM read/write** — `FetchTask`/`BurnTask` (`app/src/main/java/org/ecmdroid/task/`,
+   `AsyncTask` subclasses of `ProgressDialogTask`) page through the EEPROM via
+   `ECM.readEEPromPage()`/`writeEEPromPage()`; `EEPROM` (`EEPROM.java`) is a
+   paginated byte array with per-page dirty tracking, so burns can be
+   optimized to only write changed pages.
+5. **Continuous polling** — `EcmDroidService` runs a `ReaderThread` that
+   loops on `ECM.readRTData()` at a configurable interval (50–5000 ms),
+   broadcasts a `REALTIME_DATA` intent every cycle, and (when recording)
+   streams `[timestamp][ECM header][data]` records to a log file.
+6. **Variable definitions & scaling** — `Variable` (`Variable.java`) models a
+   single runtime/EEPROM parameter (type, offset, scale/translate, format,
+   unit) and converts raw bytes → display value (`refreshValue()`) and back
+   (`updateValue()`). Definitions come from `VariableProvider`/`BitSetProvider`,
+   backed by `DatabaseVariableProvider`/`DatabaseBitSetProvider`, both of
+   which cache lookups in an in-memory `HashMap` (the SQLite DB is hit
+   frequently during live polling, so uncached lookups would be too slow).
+7. **Logging** — recorded binary logs convert to MegaLogViewer text format
+   via `Bin2MslConverter` (`app/src/main/java/org/ecmdroid/util/`).
+
+## 4. The Wire Protocol (PDU)
+
+Source of truth: `app/src/main/java/org/ecmdroid/PDU.java`.
+
+### Frame layout
+
+```
+ byte:   0    1      2         3       4     5     6..N      N+1   N+2
+       +----+------+---------+-------+-----+-----+---------+-----+----------+
+       |SOH |sender|recipient|length |EOH  |SOT  | payload |EOT  |checksum  |
+       |0x01|      |         |       |0xFF |0x02 |         |0x03 |          |
+       +----+------+---------+-------+-----+-----+---------+-----+----------+
+```
+
+- `length` = `payload.length + 1` (the constructor adds 1; see
+  `PDU(byte sender, byte recipient, byte[] payload)`, `PDU.java:195-208`).
+- `checksum` = XOR of every byte from `sender` through `EOT` inclusive
+  (`PDU.checksum()`, `PDU.java:279-285`).
+- A frame is a **request** if its recipient equals the currently configured
+  ECM address (`isRequest()`); a **response** if its sender equals the ECM
+  address (`isResponse()`). The parser (`validate()`, `PDU.java:167-193`)
+  rejects short packets, missing markers, length/size mismatches, and bad
+  checksums by throwing `java.text.ParseException`.
+
+### Addressing
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `DROID_ID` | `0x00` | the app (always the sender for requests) |
+| `STOCK_ECM_ID` | `0x42` | ECM address for the Stock/P&A protocol |
+| `RACE_ECM_ID` | `0x55` | ECM address for the Factory Race protocol |
+
+`PDU.setProtocol(ECM.Protocol)` swaps a static `ECM_ID` field between these
+two values and regenerates the cached `GET_VERSION`/`GET_RT`/`GET_CSTATE`
+frames — call it (via `ECM.connect(...)`, which does this automatically)
+whenever the user changes the protocol, or every subsequent PDU will be
+addressed to the wrong ECM.
+
+### Commands
+
+| Constant | Value | Purpose | Built by |
+|---|---|---|---|
+| `CMD_VERSION` | `0x56` (`'V'`) | Identify the ECM (returns a version string like `BUEIB310 12-11-03`) | `PDU.getVersion()` |
+| `CMD_RTDATA` | `0x43` (`'C'`) | Fetch one snapshot of runtime data | `PDU.getRuntimeData()` |
+| `CMD_GET` | `0x52` (`'R'`) | Read `len` bytes from EEPROM `pageno` at `offset` | `PDU.getRequest(pageno, offset, len)` |
+| `CMD_SET` | `0x57` (`'W'`) | Write `len` bytes to EEPROM `pageno` at `offset` | `PDU.setRequest(pageno, offset, data, pos, len)` |
+| `ACK` | `0x06` | Acknowledgement byte seen in some responses | `PDU.isACK()` |
+
+`CMD_GET`/`CMD_SET` payloads are `[cmd, offset, pageno, len|data...]` — note
+offset comes **before** page number in the payload (`PDU.java:113-138`).
+
+**Active test / clear-codes commands** are sent as a `CMD_SET` to page
+`0x20`, offset `0`, with the payload's 4th byte selecting the function
+(`PDU.commandRequest(Function)`, `PDU.java:145-147`):
+
+| `Function` | code | `Function` | code |
+|---|---|---|---|
+| `ClearCodes` | `1` | `Rear_Inj` | `7` |
+| `FrontCoil` | `2` | `TPS_Reset` | `8` |
+| `RearCoil` | `3` | `Fan` | `9` |
+| `Tachometer` | `4` | `Exh_Valve` | `0x0a` |
+| `FuelPump` | `5` | `Active_Intake` | `0x0b` |
+| `FrontInj` | `6` | `Shift_Light` | `0x0c` |
+
+### Payload extraction helpers
+
+- `getPayload()` strips the 6-byte header, returning everything up to (not
+  including) `EOT`/checksum.
+- `getEEPromData()` additionally strips the command/offset/page bytes: 4
+  bytes for a request, 2 for a response (`PDU.java:228-232`) — this asymmetry
+  exists because a `CMD_GET` **request** payload is `[cmd, offset, page,
+  len]` (4 bytes before the "data", which is empty in a request) while a
+  `CMD_GET`/`CMD_SET` **response** payload is `[cmd, status, data...]`.
+- `getPageNr()`/`getPageOffset()` decode page/offset from a `CMD_GET`/`CMD_SET`
+  **request** PDU (used when logging/debugging what was asked for).
+
+### Request/response cycle (`ECM.sendPDU`/`receivePDU`)
+
+`ECM.sendPDU(PDU)` writes the frame's bytes to the transport `OutputStream`
+then calls `receivePDU()`, which reads the fixed 6-byte header first (to
+learn the payload length), then reads exactly that many payload bytes plus
+`EOT` and the checksum byte, and finally constructs a `PDU` (which
+self-validates in its constructor). A read timeout (`DEFAULT_TIMEOUT` =
+1000 ms) bounds each request; TCP connects use a longer 5000 ms connect
+timeout (`ECM.java:113-114`).
+
+## 5. Transport Layer
+
+`ECM` exposes four `connect(...)` overloads (`ECM.java:153-311`), each
+producing a plain `InputStream`/`OutputStream` pair that the protocol layer
+above is transport-agnostic about:
+
+| Overload | Transport | Notes |
+|---|---|---|
+| `connect(BluetoothDevice, Protocol)` | Classic Bluetooth SPP | `createRfcommSocketToServiceRecord(UUID 00001101-0000-1000-8000-00805F9B34FB)`; blocking socket streams used directly. |
+| `connect(UsbSerialPort, Protocol)` | USB-to-serial | Wraps [usb-serial-for-android](https://github.com/mik3y/usb-serial-for-android)'s `SerialInputOutputManager`; incoming bytes are forwarded into a `PipedOutputStream`/`PipedInputStream` pair so the rest of `ECM` can treat it like a normal blocking stream. Baud rate/framing (9600 or 19200 8N1) is set by the caller — see `MainActivity.findCOMDevice()`. |
+| `connect(Context, BluetoothDevice, Protocol)` | Bluetooth LE | Delegates to `de.kai_morich.simple_bluetooth_le_terminal.SerialSocket`; blocks on a monitor object until `SerialListener.onSerialConnect()`/`onSerialConnectError()` fires, then bridges `onSerialRead()` callbacks into a `PipedInputStream` the same way as USB. |
+| `connect(String host, int port, Protocol)` | TCP/IP | Plain `java.net.Socket`, 5 s connect timeout. Mainly for bridges/simulators (e.g. `ecmsim`). |
+
+`disconnect()` (`ECM.java:319-350`) branches on the concrete socket type
+(`BluetoothSocket`/`java.net.Socket`/`SerialSocket`) or stops the USB
+`SerialInputOutputManager` if there was no `socket` object.
+
+### BLE transport internals (vendored library)
+
+`de.kai_morich.simple_bluetooth_le_terminal` (kept in-tree, treat as
+external/vendored — avoid unrelated edits) wraps Android's `BluetoothGatt`
+API into a socket-like interface and auto-detects the peripheral's UART
+profile:
+
+| Chipset | Service UUID | Delegate class |
+|---|---|---|
+| TI CC254x | `0000ffe0-...-00805f9b34fb` | `Cc245XDelegate` |
+| Nordic nRF51822 | `6e400001-b5a3-f393-e0a9-e50e24dcca9e` | `NrfDelegate` |
+| Microchip RN4870/RN4871 | `49535343-FE7D-4AE5-8FA9-9FAFD205E455` | `Rn4870Delegate` |
+| Telit Bluemod TIO 2.0 | `0000FEFB-...-00805F9B34FB` | `TelitDelegate` (credit-based flow control: separate RX/TX-credit characteristics, `minReadCredits=16`/`maxReadCredits=64`) |
+
+`SerialSocket` negotiates MTU (up to 512 bytes, `payloadSize = MTU - 3`),
+enables notifications/indications via the CCCD descriptor
+(`00002902-0000-1000-8000-00805f9b34fb`), and chunks/queues large writes.
+Device discovery/pairing UI lives in
+`de.kai_morich.simple_bluetooth_le_terminal.DevicesFragment`, which falls
+back from `BluetoothAdapter.startLeScan()` to classic
+`BluetoothAdapter.startDiscovery()` when system Location Services are
+disabled (required by Android 6–11 for BLE scans).
+
+### USB device whitelist
+
+`app/src/main/res/xml/device_filter.xml` lists the USB VID/PIDs EcmDroid
+declares support for via the `USB_DEVICE_ATTACHED` intent filter (FTDI,
+Silicon Labs CP210x, Prolific PL2303x, QinHeng CH34x/CH9102F, and several
+CDC-ACM devices such as Arduino/Teensyduino/Pi Pico). `MainActivity.findCOMDevice()`
+also independently probes via `UsbSerialProber` at connect time, so a device
+not in the manifest whitelist can still be used if selected manually and
+matched by the prober — the whitelist mainly controls which devices
+auto-launch EcmDroid when plugged in.
+
+## 6. ECM: the Central Facade
+
+`ECM` (`app/src/main/java/org/ecmdroid/ECM.java`) is a per-process singleton
+(`ECM.getInstance(Context)`) holding all live state: connection, protocol,
+the current `EEPROM` object, and the last runtime-data snapshot (`rtData`).
+
+Key enums:
+
+```java
+public enum Type { DDFI1, DDFI2, DDFI3; }       // Tuber / XB≤2007 / XB2008+,1125
+public enum Protocol { STOCK, FACTORY_RACE; }   // ECM address 0x42 vs 0x55
+```
+
+Key methods (see the class javadoc at `ECM.java:53-74` for the intended call
+order — `getInstance()` → a `connect()` overload → `setupEEPROM()` before
+touching EEPROM data):
+
+- `setupEEPROM()` — sends `PDU.getVersion()`, parses the returned version
+  string (e.g. `BUEIB310 12-11-03`) to get the 5-character ECM ID, and calls
+  `EEPROM.get(id, context)` to load page/size metadata from the SQLite DB.
+- `readRTData()` — sends `PDU.getRuntimeData()`, stores the raw payload in
+  `rtData` for `Variable`/`BitSet` lookups.
+- `readEEPromPage(Page)` / `writeEEPromPage(Page)` — page through EEPROM data
+  in 16-byte chunks via `CMD_GET`/`CMD_SET`. Page 0 is special-cased: it's
+  addressed as page `0xFF` and, on write, only two variables
+  (`Variables.LFuel1`, `Variables.KBaro` — see `PAGE_ZERO_VARS_TO_WRITE`,
+  `ECM.java:121-124`) are ever written back, to avoid clobbering
+  factory-calibration bytes that share page 0 with user-editable ones.
+- `getErrors(ErrorType)` — decodes current (`CDiag0`-`CDiag9`), recent
+  (`EDiag0`-`EDiag10`), or stored (`HDiag0`-`HDiag9`) diagnostic bitsets into
+  `Error` objects (code + description).
+- `runTest(Function)` — sends `PDU.commandRequest(function)` for active
+  tests/TPS reset/clear-codes.
+- `getEEPROMValue(name)` / `getRuntimeValue(name)` — look up a `Variable` by
+  name via `VariableProvider`, then refresh it from `eeprom.getBytes()` or
+  `rtData` respectively.
+- `setEEPROMValue(Variable)` / `setEEPROMBits(BitSet)` — write a new value
+  into the in-memory `EEPROM` byte array and mark the containing `Page` as
+  **touched** (dirty) via `EEPROM.Page.touch(offset, length)`. Nothing is
+  sent to the ECM until a `BurnTask` runs.
+
+## 7. EEPROM / Variable / BitSet Data Model
+
+### `EEPROM` (`EEPROM.java`)
+
+A paginated byte array plus metadata:
+
+- `EEPROM.get(name, Context)` — queries the `eeprom`/`pages` tables for the
+  ECM identified by `name` (first 5 chars of the version string), builds an
+  `EEPROM` with an `ArrayList<Page>` and an empty `byte[length]` buffer.
+  Page 0 is placed at the **end** of the buffer (`pg.start = eeprom.length -
+  pg.length`), all other pages are laid out sequentially from offset 0 —
+  mirroring how the physical ECM addresses page 0 as `0xFF`.
+- `EEPROM.load(Context, id, InputStream)` — builds an EEPROM template via
+  `get()`, overwrites its bytes with a loaded file's contents, and marks
+  every page touched (so a freshly-loaded file can be burned in full).
+- `EEPROM.size2id(Context, length)` — maps a raw file's byte length back to
+  one or more candidate ECM IDs (some ECM types share a EEPROM size, hence
+  an array return and a disambiguation prompt in `EEPROMFragment`).
+- Inner class `Page`: `nr`, `length`, `start` (byte offset into the
+  `EEPROM`'s buffer), `touched`. `getBytes(offset, length, buffer,
+  bufferPos)` copies from `start + offset`. `touch()`/`touch(offset, length)`
+  mark it dirty; `BurnTask` only re-writes touched pages when "optimized
+  burning" is enabled.
+- `isTouched()` (any page dirty) gates the Setup/EEPROM screens' Save/Apply
+  buttons and the "overwrite unsaved changes?" confirmation before a Fetch.
+- `isEepromRead()` distinguishes "we have real page bytes from a Fetch/Load"
+  from "we only have page/size metadata" — used to decide whether to show
+  serial/mfg-date/calibration fields on the Main screen.
+
+### `Variable` (`Variable.java`)
+
+Represents one named runtime or EEPROM parameter:
+
+- `DataType`: `SCALAR`, `VALUE`, `BITS`, `BITFIELD`, `ARRAY`, `AXIS`, `TABLE`,
+  `MAP`, `STRING`.
+- `refreshValue(byte[] tmp)` reads a little-endian multi-byte integer at
+  `offset` (width = element size), and for numeric types applies
+  `scale * raw + translate` before formatting via `DecimalFormat` (bit
+  types are kept as raw shorts and formatted as binary strings instead).
+- `updateValue(byte[] bytes)` is the inverse: `(displayValue - translate) /
+  scale`, written back little-endian at `offset`.
+- `parseValue(String)`/`parseValueAt(...)` parse user text input, throwing
+  `NumberFormatException` on bad input (caught by the calling fragment and
+  surfaced as a toast).
+
+### `BitSet`/`Bit` (`BitSet.java`, `Bit.java`)
+
+A `BitSet` is up to 8 `Bit`s packed into one byte (`bits[bitNr]`, 0-7). Each
+`Bit` carries a diagnostic `code` (DTC, e.g. `P0001`) and a human `remark`
+where applicable. `BitSet.updateValue(byte[])` masks out only the bits it
+owns and ORs in new values, so multiple `BitSet`s can safely share a byte.
+Negative offsets throughout this layer (`Bit`, `BitSet`, `Variable`) mean
+"relative to the end of the buffer", i.e. page 0.
+
+### `Error` (`Error.java`)
+
+Simple `{code, description, ErrorType}` tuple; `ErrorType` is `CURRENT`
+(from `CDiag*` runtime bitsets), `RECENT` (`EDiag*`), or `STORED` (`HDiag*`
+EEPROM bitsets). Built exclusively by `ECM.getErrors()`.
+
+## 8. Bundled ECM-Definitions Database
+
+The app ships a gzip-compressed SQLite database,
+`app/src/main/assets/ecmdroid.db.gz`, sourced from ecmspy.com MySQL dumps.
+Despite the `.gz` suffix, code opens it as `assets.open("ecmdroid.db")`
+(`DBHelper.setupDB()`, `DBHelper.java:65-66`) — Android's `AssetManager`
+transparently gzip-decompresses any packaged asset stored under a `.gz`
+name when it's opened without that suffix, so no explicit decompression
+code is needed.
+
+`DBHelper` (`SQLiteOpenHelper`) copies the asset into the app's private DB
+directory on first launch or whenever `DB_VERSION` (`DBHelper.java:40`)
+changes; `EcmDroidApp.onCreate()` calls `setupDB()` before any other
+component runs.
+
+### Schema
+
+| Table | Purpose |
+|---|---|
+| `eeprom` | One row per ECM ID: `name`, `category`, `type` (DDFI/-2/-3 string), `size`, `xsize` (total EEPROM length incl. page 0). |
+| `pages` | Page layout per `category`: `page` number, `size` in bytes. |
+| `rtoffsets` | Runtime-data variable offsets: `category`, `varname`, `type`, `offset`, `size`, `scale`, `translate`, `format`, `secret`. |
+| `eeoffsets` | EEPROM variable offsets: `category`, `varname`, `type`, `offset`, `elemsize`, `cols`, `rows`, `scale`, `translate`, `format`, `secret`. |
+| `names` | Display metadata per `varname`: `origname`, `name`, `secret`, `description`, `units`, `remark`. |
+| `bits` | Per-`varname` bit layout: `byte`, and 8 columns each of `bitname{1-8}`, `bit{1-8}`, `dtc{1-8}`. |
+
+`secret=1` rows are internal/debug parameters filtered out of the app's
+variable pickers (`... AND secret=0` in the `DatabaseVariableProvider`/
+`DatabaseBitSetProvider` queries).
+
+`DatabaseVariableProvider`/`DatabaseBitSetProvider` (`app/src/main/java/org/ecmdroid/`)
+run raw SQL via `SQLiteDatabase.rawQuery()` (no ORM) and cache every lookup
+in a `HashMap` keyed by `rt#<name>`/`ee#<name>` (variables) or `<name>`
+(bitsets); the cache is cleared whenever the connected ECM's ID changes.
+**Follow this pattern for any new DB-backed lookup** — the DB is queried on
+every live-poll cycle, so uncached queries would be a real perf problem.
+
+### Regenerating the bundled database
+
+See [`README.db`](../README.db) for the exact steps; summary:
+
+1. Import an ecmspy.com MySQL backup into a scratch MySQL DB.
+2. `sh scripts/mysql2sqlite.sh -u<user> -p<password> <db> > ecmdroid.sq3`
+   (awk-based MySQL-dump → SQLite statement converter).
+3. Strip all column `COMMENT`s from the generated SQL (unsupported by
+   SQLite3).
+4. `sqlite3 assets/ecmdroid.db < ecmdroid.sq3` to build the file.
+5. `gzip -f assets/ecmdroid.db` to replace `assets/ecmdroid.db.gz`.
+6. **Bump `DB_VERSION` in `DBHelper.java`** so installed apps re-extract the
+   new database on next launch — forgetting this step means the new data is
+   bundled but never actually installed on any upgraded device.
+
+## 9. Background Service and Threading
+
+No coroutines/RxJava/Executors anywhere in the app. Three threading patterns
+are used, consistently:
+
+1. **`AsyncTask` subclasses of `ProgressDialogTask`** (`app/src/main/java/org/ecmdroid/task/`)
+   for one-shot ECM I/O with a modal progress dialog:
+   - `ProgressDialogTask` (base): freezes screen orientation
+     (`Utils.freezeOrientation`) for the duration, shows a non-cancelable
+     `ProgressDialog`, restores orientation and displays an error `Toast` if
+     `doInBackground()` returns a non-null `Exception`.
+   - `FetchTask`: confirms overwrite of unsaved changes, then
+     `setupEEPROM()` + `readRTData()` + `readEEPromPage()` for every page.
+   - `BurnTask`: shows a "burn at your own risk" confirmation, verifies the
+     live ECM's version matches the EEPROM's ID before writing (refuses via
+     `cancel(true)` on mismatch), writes touched-only or all pages depending
+     on the `enable_fast_burning` preference, and clears dirty flags
+     (`eeprom.saved()`... — actually pages' `touched` flags) on success.
+   - `MainActivity.ConnectTask` extends `FetchTask` to combine
+     connect-then-initial-fetch into one progress dialog.
+
+2. **`EcmDroidService.ReaderThread`** (`EcmDroidService.java`) — a plain
+   `Thread` polling `ecm.readRTData()` at a configurable interval (250 ms
+   default, 50 ms minimum), using `synchronized`/`wait()`/`notify()` to
+   sleep when neither reading nor recording is active rather than
+   busy-looping. Each cycle:
+   - On success: broadcasts `EcmDroidService.REALTIME_DATA`; if recording,
+     appends `[4-byte centisecond timestamp][raw rtData bytes]` to the open
+     log `FileOutputStream`.
+   - On failure: increments a `readFailures` counter and logs, but keeps
+     running (no crash/backoff-to-disconnect logic — a flaky link just shows
+     up as gaps in the log/UI).
+   - `startRecording(FileOutputStream, interval, ECM)`/`stopRecording()`
+     toggle the recording flag and post `RECORDING_STARTED`/`RECORDING_STOPPED`
+     broadcasts; a persistent notification (channel `ecmdroid_logrecorder`)
+     is shown while recording, deep-linking back to `LogFragment`.
+
+3. **`ServiceConnection`/`BroadcastReceiver`** — `MainActivity`/`DataChannelFragment`/`LogFragment`
+   bind to `EcmDroidService` via `ServiceConnection`, and register a
+   `BroadcastReceiver` for `REALTIME_DATA`/`RECORDING_STARTED`/`RECORDING_STOPPED`
+   in `onResume()`, unregistering in `onPause()`. UI never talks to the
+   `ReaderThread` directly — always through the service's public
+   start/stop/accessor methods, which are what stay thread-safe
+   (`synchronized`) against the reader thread.
+
+## 10. UI Layer
+
+`MainActivity` (`app/src/main/java/org/ecmdroid/activities/MainActivity.java`)
+is the single navigation-drawer host; `switchToFragment(int id)` swaps the
+`R.id.content_frame` fragment. A `isTransactionSafe` flag defers fragment
+switches that arrive while the activity is mid-transition (e.g. during
+rotation), executing them once `onPostResume()` marks it safe again — needed
+because `FragmentTransaction`s during `onSaveInstanceState()` throw.
+
+| Drawer item | Fragment | Purpose |
+|---|---|---|
+| ECM Information | `MainFragment` | identity fields, protocol picker |
+| Trouble Codes | `TroubleCodeFragment` | read/clear current & stored DTCs |
+| Active Tests | `ActiveTestsFragment` | fire `PDU.Function` tests, TPS reset |
+| Data Channels | `DataChannelFragment` | 5-slot live gauge list, bound to `EcmDroidService` |
+| Setup | `SetupFragment` | `PreferenceFragment` rendering `res/xml/ecm_setup.xml`, bidirectionally bound to `Variable`/`BitSet` |
+| Log Recorder | `LogFragment` | start/stop binary logging, optional `.msl` conversion |
+| EEPROM | `EEPROMFragment` | raw hex `GridView` + `CellEditorDialogFragment` byte editor, file save/load, Fetch/Burn |
+| Torque Values | `TorqueValuesFragment` (legacy `PreferenceActivity`) | static reference data from `res/xml/torque_values.xml` |
+| Settings | `PrefsActivity` | connection type/host/port, storage location, burn toggles, keep-screen-on |
+| About | `AboutActivity` | WebView of `assets/about.html` |
+
+`SetupFragment` is worth understanding as the canonical example of the
+Setup-editing pattern: it recursively walks the `PreferenceScreen` tree from
+`res/xml/ecm_setup.xml`, resolves each `Preference`'s `key` against either a
+`BitSet` (key syntax `varname:bit[,bit...]`, matched by `Constants.BIT_PATTERN`)
+or a plain `Variable`, sets `pref.setPersistent(false)` (Android's own
+preference storage is bypassed entirely — the `ECM`/`EEPROM` singleton *is*
+the persistence layer), and on `onPreferenceChange()` calls
+`ecm.setEEPROMValue(Variable)`/`ecm.setEEPROMBits(BitSet)`, revealing a
+Save/Apply button once `ecm.isConnected() && ecm.getEEPROM().isTouched()`.
+
+## 11. Async Task Pattern
+
+Every long-running ECM/file operation follows the same shape — a two-phase
+`start()`/`doInBackground()` split so any needed confirmation dialog runs
+*before* the background work begins:
+
+```java
+class SomeTask extends ProgressDialogTask {
+    SomeTask(Activity ctx) { super(ctx, ctx.getString(R.string.some_title)); }
+
+    void start() {
+        if (/* needs confirmation, e.g. unsaved changes */) {
+            new AlertDialog.Builder(context)
+                .setPositiveButton(..., (d, w) -> execute())
+                .setNegativeButton(..., (d, w) -> d.cancel())
+                .show();
+        } else {
+            execute();
+        }
+    }
+
+    @Override protected Exception doInBackground(Void... v) {
+        try {
+            publishProgress("...");   // updates the ProgressDialog message
+            // ECM I/O here
+            return null;               // success
+        } catch (Exception e) {
+            return e;                  // ProgressDialogTask shows it as a Toast
+        }
+    }
+}
+```
+
+Exceptions are **returned**, not thrown, from `doInBackground()` — this is
+the app-wide error-reporting convention for background work; `onPostExecute()`
+in the base class turns a non-null result into a `Toast`.
+
+## 12. Binary Log Format and MSL Conversion
+
+### Binary log format (written by `EcmDroidService.ReaderThread`)
+
+```
+[5-byte ECM ID header]
+repeat:
+  [4-byte int timestamp, centiseconds since recording start]
+  [rtLen-byte runtime buffer]     // last byte of the buffer is an XOR checksum
+```
+
+`rtLen` (and therefore the on-wire runtime buffer size) depends on ECM
+category:
+
+| Category | ECM IDs (prefix) | `rtLen` |
+|---|---|---|
+| 1 (DDFI-1/Tuber) | `BUEKA`, `BUEJA` | 99 |
+| 2 (DDFI-2) | `BUECB`, `BUEGB`, `BUEIB`, `BUEIC`, `B2RIB` | 103–107 |
+| 3 (DDFI-3) | `BUEOD`, `BUEWD`, `BUEYD`, `BUEZD`, `BUE1D`, `BUE2D`, `BUE3D`, `B3R1D`, `B3R3D` | 135 |
+
+### Conversion (`Bin2MslConverter`, `app/src/main/java/org/ecmdroid/util/Bin2MslConverter.java`)
+
+`convert(InputStream, PrintWriter)` (an `Observable`, so callers such as
+`LogFragment.StopTask` can `addObserver()` for progress-string updates every
+~500 ms and support cancellation via `cancel()`):
+
+1. Reads the 5-byte ECM-ID header, maps it to category and loads the
+   matching **offset table** resource — `runtime1.tab`/`runtime2.tab`/`runtime3.tab`
+   (`app/src/main/resources/`), a tab-separated file with one row per
+   exported parameter (`export name`, byte `offset`, `size` 1 or 2, `scale`,
+   `translate`, integer/float `format`).
+2. Per record: validates the trailing XOR checksum (byte-for-byte against
+   `rtBuffer[1..rtLen-2]`); silently discards the record on mismatch rather
+   than aborting the whole conversion.
+3. Computes derived columns not present verbatim in the offset table:
+   `Gego`/`Gego1` (closed-loop EGO correction, or open-loop AFV fallback,
+   selected by a bit in the `Flags2` byte) and a composite `Engine` state
+   byte assembled from `Flags1` bits plus warmup/acceleration thresholds.
+4. Writes a MegaLogViewer-compatible `.msl`: header line
+   `"EcmDroid/Bin2Msl <ECM_TYPE>"`, a tab-separated column-name header, then
+   one tab-separated row per valid record (`Number`, `Time` in seconds,
+   `Gego`[, `Gego1` for category 3], `Engine`, then every exported
+   parameter), CRLF line endings for MegaLogViewer compatibility.
+
+If you add a new exportable runtime parameter, it goes in the SQLite
+`rtoffsets`/`names` tables (for live display) **and** in the matching
+`runtime{1,2,3}.tab` resource (for log conversion) — the two are
+independent data sources that happen to describe the same underlying bytes.
+
+## 13. Testing
+
+Only **instrumented** tests exist, under `app/src/androidTest/java/org/ecmdroid/`
+(JUnit 4 + `AndroidJUnit4` runner; Espresso is a declared dependency but
+unused by current tests). There is no `app/src/test/` JVM unit-test source
+set and no CI pipeline configured in this repo — tests are run locally.
+
+| Test class | Covers |
+|---|---|
+| `TestPDU` | Frame construction/parsing, checksum validation |
+| `TestECM` | ECM identification / EEPROM setup flow |
+| `TestEEPROM` | Page layout, load/size2id |
+| `TestVariableProvider` | DB-backed variable lookups and scaling |
+| `TestBitSetProvider` | DB-backed bitset/DTC lookups |
+| `TestBin2Msl` | Binary log → `.msl` conversion, using fixture logs |
+| `TestUtils` | Misc helpers (hexdump, string checks, etc.) |
+
+Fixtures live in `app/src/androidTest/resources/` — real captured `.eeprom`
+dumps (`BUEIB.eeprom`, `BUE2D.eeprom`), binary runtime snapshots
+(`RT_BUEIB.bin`, `RT_BUEIB242.bin`), binary logs (`BUEIB_log.bin`,
+`BUE2D_log.bin`) and a reference `.msl` conversion output (`BUE2D_log.msl`).
+**Reuse these fixtures** for new protocol/converter tests rather than
+inventing new binary formats or mocking — there is no Robolectric/mocking
+framework configured, and the project's existing convention is to test
+against real captured data.
+
+```bash
+./gradlew connectedAndroidTest         # all instrumented tests
+./gradlew connectedDebugAndroidTest    # debug variant only
+```
+
+Naming convention for new tests: `Test<Component>.java`, methods prefixed
+`test`, placed alongside the existing classes under
+`app/src/androidTest/java/org/ecmdroid/`.
+
+## 14. Code Conventions
+
+- **Language**: plain Java 8 (`sourceCompatibility`/`targetCompatibility` =
+  `1.8`). Gradle build files are Kotlin DSL (`.kts`), but there is no Kotlin
+  *application* code — don't introduce Kotlin without discussing it first.
+- **Naming**: classes `PascalCase`; methods `camelCase`; constants
+  `UPPER_SNAKE_CASE`; every class carries a `private static final String
+  TAG` for `Log.d/i/w/e`.
+- **Error handling**: exceptions, not return codes. `PDU`'s constructor
+  throws `java.text.ParseException` on malformed frames; failures surface to
+  the user via `Toast` or `AlertDialog`, generally by returning the
+  `Exception` from an `AsyncTask.doInBackground()` (see §11).
+- **Dependency management**: no DI framework — singletons via static
+  `getInstance(Context)`; fragments reach their host `Activity`/`Service`
+  via `getActivity()`/`ServiceConnection`.
+- **State**: the `ECM` singleton is the single source of truth for
+  connection/protocol/EEPROM state; `SharedPreferences` hold *user* settings
+  (protocol index, storage location URI, log interval, keep-screen-on,
+  per-ECM data-channel selection); `MainActivity` persists the active drawer
+  fragment across rotation via `onSaveInstanceState`.
+- **Database access**: raw SQL via `SQLiteDatabase.rawQuery()`, never an
+  ORM. New lookups should get an in-memory `HashMap` cache exactly like
+  `DatabaseVariableProvider`/`DatabaseBitSetProvider` — the DB is queried
+  every live-poll cycle.
+- **Resource naming**: layouts named after their feature (`main.xml` ↔
+  `MainFragment`, `log.xml` ↔ `LogFragment`); menus `*_menu.xml`/
+  `main_drawer.xml`; drawables descriptive (`ic_connected.xml`).
+- **Vendored code**: `de.kai_morich.simple_bluetooth_le_terminal` is
+  third-party BLE code kept in-tree — treat it as external and avoid
+  unrelated edits/reformatting.
+
+## 15. Common Pitfalls
+
+- **Forgetting to bump `DBHelper.DB_VERSION`** after regenerating
+  `ecmdroid.db.gz` — installed apps only re-extract the asset when the
+  version constant changes (§8).
+- **Editing page 0 semantics without reading `PAGE_ZERO_VARS_TO_WRITE`** —
+  page 0 has a restricted write set on purpose (`ECM.java:121-124`); adding
+  a new page-0-writable variable to the Setup UI without also adding it here
+  means edits appear to work but are silently never burned.
+- **Changing the PDU frame shape without updating both request and
+  response paths** — `getPayload()` vs. `getEEPromData()` intentionally
+  strip a different number of header bytes depending on `isRequest()`
+  (§4); a naive change to one usually breaks the other.
+- **New runtime-exported parameters need two edits**, not one: the SQLite
+  `rtoffsets`/`names` tables (live UI) and the `runtime{1,2,3}.tab` resource
+  (log conversion) — see §12.
+- **Switching `ECM.Protocol` without going through `ECM.connect(...)`** —
+  `PDU.setProtocol()` must run before any further PDU is built, or requests
+  go to the wrong `ECM_ID` and silently time out.
+- **Un-cached DB lookups on the polling hot path** — anything called from
+  `EcmDroidService.ReaderThread` runs up to 20×/second (50 ms interval);
+  always route new variable/bitset lookups through the provider caches.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,319 @@
+# EcmDroid User Guide
+
+EcmDroid is an Android app for diagnosing and tuning Buell motorcycles that run a
+Zeeltronic/ecmspy-derived DDFI(-1, -2, -3) Engine Control Module (ECM). It talks
+directly to the ECM over the motorcycle's factory diagnostic connector, using a
+Bluetooth, Bluetooth LE, or USB-to-serial adapter.
+
+This guide covers everything an owner/tuner needs: what hardware to buy, how to
+pair it, and how to use every screen in the app. For source-level and build
+documentation, see [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md).
+
+## Table of Contents
+
+1. [What EcmDroid Can Do](#1-what-ecmdroid-can-do)
+2. [Supported Motorcycles / ECMs](#2-supported-motorcycles--ecms)
+3. [Hardware You Need](#3-hardware-you-need)
+4. [Installing EcmDroid](#4-installing-ecmdroid)
+5. [Connecting to the ECM](#5-connecting-to-the-ecm)
+6. [App Settings](#6-app-settings)
+7. [Screen-by-Screen Guide](#7-screen-by-screen-guide)
+8. [Working with EEPROM Files](#8-working-with-eeprom-files)
+9. [Recording and Converting Logs](#9-recording-and-converting-logs)
+10. [Safety: Reading vs. Writing (Burning)](#10-safety-reading-vs-writing-burning)
+11. [Troubleshooting](#11-troubleshooting)
+12. [Privacy](#12-privacy)
+
+---
+
+## 1. What EcmDroid Can Do
+
+- Identify the connected ECM (type, protocol, serial number, manufacturing date,
+  calibration ID).
+- Read live ("runtime") sensor data: RPM, throttle position, coolant
+  temperature, air/fuel value, battery voltage, etc.
+- Read current, recent, and stored diagnostic trouble codes, and clear them.
+- Trigger "active tests" — manually fire the fuel pump, ignition coils,
+  injectors, cooling fan, exhaust valve, shift light, or reset the TPS
+  (throttle position sensor) baseline.
+- Read and edit the ECM's EEPROM: named configuration parameters (via the
+  Setup screen) or raw hex bytes (via the EEPROM screen).
+- Save/load EEPROM dumps to/from a file (`.xpr`/legacy `.epr` format) so you
+  can back up a tune or share it.
+- Record live runtime data to a binary log file and convert it to
+  MegaLogViewer (`.msl`) format for graphing/analysis.
+- Look up factory torque specifications for Buell XB fasteners.
+
+EcmDroid does **not** contain any tuning tables/maps editor beyond what the ECM
+exposes as named EEPROM variables — it is a diagnostic and calibration tool,
+not a stand-alone fuel/ignition map editor.
+
+## 2. Supported Motorcycles / ECMs
+
+The app recognizes three ECM generations, auto-detected from the ECM's version
+string once connected:
+
+| App label | Motorcycles                              |
+|-----------|-------------------------------------------|
+| DDFI      | Buell "Tuber" models (early DDFI-1)        |
+| DDFI-2    | Buell XB models through 2007               |
+| DDFI-3    | Buell XB 2008+, 1125R, 1125CR               |
+
+Each ECM also runs one of two **protocols**, selectable in the app (Main
+screen) and identifiable by the marking on the ECM casing:
+
+- **Stock / P&A** — the vast majority of ECMs. Serial adapter must be set to
+  **9600 baud, 8N1, no handshake**.
+- **Factory Race** — identified by an ***engraved*** "RACE USE ONLY" marking.
+  Serial adapter must be set to **19200 baud, 8N1, no handshake**.
+
+(A ***printed*** "RACE USE ONLY" marking indicates a P&A Race ECM, which still
+uses the Stock protocol/baud rate.)
+
+If you pick the wrong protocol, the app will fail to identify the ECM (version
+string won't parse) — switch the protocol and reconnect.
+
+## 3. Hardware You Need
+
+You need an adapter that plugs into the motorcycle's diagnostic connector
+(under the seat on "S" models, behind the front mask on "R" models) and
+exposes a serial link to your phone/tablet. EcmDroid supports four transport
+types:
+
+| Type | Notes |
+|---|---|
+| **Classic Bluetooth (SPP)** | Most common. Any Bluetooth-serial adapter (e.g. based on HC-05/06) that presents a Serial Port Profile. [Build guide](https://ecmspy.com/btwireless2.shtml) or buy pre-built from vendors such as [buell-parts.com](https://buell-parts.com/Bluetooth-Adapter-Version-2). |
+| **Bluetooth LE** | Adapters built around Nordic nRF51822, Texas Instruments CC254x, Microchip RN4870/RN4871, or Telit Bluemod TIO 2.0 chipsets are auto-detected. No OS-level pairing required. |
+| **USB-to-serial adapter** | Plug an FTDI, Silicon Labs CP210x, Prolific PL2303, or QinHeng CH340/CH341/CH9102 USB-serial cable into your Android device (via a USB-OTG cable) wired to the diagnostic connector. Requires Android USB host support. |
+| **TCP/IP** | Connect to a Bluetooth-to-WiFi or serial-to-network bridge by host/port (advanced/legacy option). |
+
+For **Classic Bluetooth**, pair the adapter first using Android's own
+**Settings → Bluetooth** app — EcmDroid does not do OS-level pairing itself.
+For **BLE**, no separate pairing step is needed; the app scans for and
+connects to the adapter directly.
+
+Also check out [ecmsim](https://github.com/ecmdroid/ecmsim), a standalone ECM
+simulator you can use to try EcmDroid without a real motorcycle.
+
+## 4. Installing EcmDroid
+
+- Requires **Android 8.0 (API 26) or later**.
+- Install the APK from your preferred source (F-Droid/GitHub releases/Play
+  Store, depending on distribution) or build it yourself — see
+  [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md#building).
+- On first launch the app extracts its bundled ECM-definitions database; you
+  may briefly see an "Updating database…" toast.
+
+### Permissions
+
+EcmDroid will ask for, or use, the following at runtime:
+
+- **Nearby devices (Bluetooth Scan/Connect)** — required to list and connect
+  to Bluetooth/BLE adapters (Android 12+).
+- **Location** — required by Android itself for classic BLE scanning on
+  Android 6–11 (`ACCESS_FINE_LOCATION`/`ACCESS_COARSE_LOCATION`). EcmDroid
+  does not use your location for anything else; if location services are
+  turned off it automatically falls back to classic Bluetooth discovery for
+  BLE devices instead.
+- **Notifications** — shown while a log recording is in progress, so you can
+  see recording status from the notification shade (Android 13+ requires you
+  to grant this explicitly).
+- **Storage folder access** — you choose a folder (via the system file
+  picker) where EEPROM dumps and log files are saved; EcmDroid never gets
+  broad storage access.
+
+## 5. Connecting to the ECM
+
+1. Tap the round connect button (bottom right, colored **red** when
+   disconnected).
+2. Depending on the connection type configured in **Settings**:
+   - **Classic Bluetooth**: pick your already-paired adapter from the list.
+   - **Bluetooth LE**: the app scans for nearby BLE devices; tap yours in the
+     list. Use the menu's "Scan"/"Stop scan" and "Bluetooth settings"
+     shortcuts if needed.
+   - **USB-to-serial**: plug in the adapter (or it may already be attached);
+     grant the USB permission prompt when Android shows it.
+   - **TCP/IP**: connects automatically to the host/port set in Settings.
+3. The button turns **gray** while connecting, then **green** once EcmDroid
+   has successfully identified the ECM. Tap it again anytime to disconnect.
+
+If the connect button stays red or you get a "Could not open COM port" /
+"connection failed" message, see [Troubleshooting](#11-troubleshooting).
+
+Once connected, the **ECM Information** screen (the app's home screen) shows
+the ECM ID, type, protocol, serial number, manufacturing date, layout
+revision, country ID and calibration ID (the latter group only appears after
+an EEPROM read).
+
+## 6. App Settings
+
+Open the navigation drawer (swipe from the left edge, or tap the hamburger
+icon) → **Settings**:
+
+| Setting | Purpose |
+|---|---|
+| Storage location | Folder (chosen via system file picker) where EEPROM dumps and log files are written/read. Set this before saving/loading/logging. |
+| ECM connection type | Classic Bluetooth / Bluetooth LE / TCP/IP / USB-to-serial adapter. |
+| TCP host / TCP port | Only used when connection type is TCP/IP. |
+| Hide non-existent EEPROM variables | On the Setup screen, hides parameters that don't apply to your detected ECM model. |
+| Enable EEPROM burning | **Off by default.** Must be turned on before you can write (burn) any changes back to the ECM. Read this twice before enabling — see [§10](#10-safety-reading-vs-writing-burning). |
+| Optimized burning | Only available once burning is enabled. When on, only EEPROM pages you actually changed are re-written, which is faster and reduces write-cycle wear. |
+| Keep screen on | Prevents the screen from locking while EcmDroid is in the foreground (handy for long logging sessions or a phone mounted on the bike). |
+
+The **ECM Protocol** selector (Stock/P&A vs. Factory Race) lives on the main
+ECM Information screen, not in Settings — see [§2](#2-supported-motorcycles--ecms).
+
+## 7. Screen-by-Screen Guide
+
+Navigate between screens using the left-hand drawer.
+
+### ECM Information (home screen)
+
+Shows ECM identity fields described in [§5](#5-connecting-to-the-ecm) and lets
+you pick the protocol (Stock/P&A vs. Factory Race) before connecting.
+
+### Trouble Codes
+
+- **Read Errors** fetches and displays two lists: *Current* errors (active
+  right now) and *Stored* errors (persisted in the ECM even after they clear).
+  Each line shows the code and its description.
+- **Clear Errors** asks for confirmation, then tells the ECM to clear its
+  stored codes and re-reads the error lists.
+
+### Active Tests
+
+- Pick a test from the list (front/rear ignition coil, tachometer, fuel pump,
+  front/rear injector, cooling fan, exhaust valve, active intake, shift
+  light) and tap **Start Test** to fire it once. Useful for confirming a
+  component (e.g. the fuel pump relay or an injector) is wired and
+  responding, without starting the engine.
+- **TPS Reset** re-learns the throttle position sensor's closed-throttle
+  baseline. Follow the on-screen prompt (procedure differs slightly for
+  DDFI-3 ECMs) — typically: key on, don't touch the throttle, confirm.
+- Tests require an active connection; buttons are disabled until you connect.
+
+### Data Channels
+
+- A live gauge list showing up to 5 configurable channels at once (defaults:
+  battery voltage, RPM, throttle position, air/fuel value, coolant
+  temperature).
+- Tap a channel row's dropdown to swap in a different runtime variable.
+- Toggle the switch to start/stop live streaming; values refresh continuously
+  while it's on (values come from the ECM roughly 4x/second by default).
+- Your channel selections are remembered per-ECM.
+
+### Setup (named parameters)
+
+- A categorized settings-style list of ECM configuration parameters — system
+  options, noise-reduction/retard settings, airbox/baro-pressure sensor
+  configuration, shifter/shift-light configuration, error-reporting masks,
+  RPM/temperature limits, fan on/off setpoints, AFV calibration, O2 sensor
+  setup, etc.
+- Checkboxes toggle individual configuration bits; text fields hold scaled
+  numeric values (e.g. RPM limits, temperatures, voltages) with their real
+  units — you type the human value, not a raw byte.
+- Edits are staged locally. An **Apply Changes / Save** button appears once
+  you have unsaved edits and are connected; use it (or the EEPROM screen's
+  **Burn** action) to actually write changes to the ECM — see
+  [§10](#10-safety-reading-vs-writing-burning).
+
+### EEPROM (raw byte editor)
+
+- A hex grid of every byte in the ECM's EEPROM, addressed by offset.
+- Tap a cell to see details in the info panel: offset (hex/decimal), byte
+  value (hex/decimal), the 16-bit word formed with the adjacent byte
+  (hi/lo, hex/decimal), and the nearest known variable name, if any.
+- **Long-press** a cell to open the byte editor dialog: type a value 0–255,
+  or use the quick buttons (`0`, `255`, `-16`, `+16`, `÷2`, `×2`) then **Set**.
+- Menu actions: **Fetch** (read all EEPROM pages from the ECM), **Burn**
+  (write changed pages back), **Save** (export the current EEPROM to a file),
+  **Load** (import an EEPROM file). See [§8](#8-working-with-eeprom-files).
+
+### Log Recorder
+
+- Choose a sample interval (No Delay up through 5 seconds) from the dropdown.
+- Tap **Start** to begin recording; live TPS/RPM/coolant-temp readouts and a
+  running byte/record counter are shown while recording.
+- Tap **Stop** to end the session. The binary log is written into your
+  configured storage folder as `yyyyMMdd_hhmmss.bin`.
+- Enable the **Convert to MSL** switch before stopping to automatically
+  produce a companion MegaLogViewer-compatible `.msl` text file you can graph
+  in MegaLogViewer or open in a spreadsheet. See [§9](#9-recording-and-converting-logs).
+
+### Torque Values
+
+A static reference of factory torque specifications (Nm) for Buell XB
+chassis/engine fasteners, sourced from the factory service manual and the
+xborgforum community wiki. No connection required; purely informational.
+
+## 8. Working with EEPROM Files
+
+- **Save**: EEPROM screen menu → **Save**. Writes the full current EEPROM
+  image (whatever is currently loaded/fetched) to a file named
+  `<ECM-ID>_yyyyMMdd-hhmmss.xpr` in your chosen storage folder. This is the
+  same `.xpr` format used by ECMSpy, so files are interchangeable with that
+  tool. Legacy `.epr` dumps can also be loaded (not saved).
+- **Load**: EEPROM screen menu → **Load**, pick a file. EcmDroid detects the
+  ECM type from the file size; if more than one ECM type shares that size,
+  you'll be prompted to pick the correct one. If you're connected to a real
+  ECM, the loaded file's ID must match the connected ECM's ID.
+- **Fetch**: reads all EEPROM pages fresh from the connected ECM, overwriting
+  any unsaved local edits (you'll be asked to confirm if you have unsaved
+  changes).
+- **Burn**: writes local edits back to the connected ECM — see next section.
+
+## 9. Recording and Converting Logs
+
+- Logs are recorded in a compact binary format: a small ECM-type header
+  followed by timestamped runtime-data snapshots, each with a checksum.
+- Recording interval options range from "No Delay" (as fast as the ECM will
+  respond) to a fixed 5-second period — shorter intervals produce denser data
+  but larger files and use more phone/bike-adapter bandwidth.
+- Converting to `.msl` (MegaLogViewer format) turns the binary log into a
+  tab-separated text file with one row per sample and one column per
+  parameter (RPM, TPS, AFV, coolant temp, EGO correction, etc.), plus derived
+  columns like closed/open-loop EGO correction ("Gego") and an engine-state
+  byte. This is done automatically at Stop time if you enabled the convert
+  switch, or can be triggered from a saved `.bin` file.
+- Corrupted samples (failed checksum) are silently dropped during conversion
+  rather than aborting the whole log.
+
+## 10. Safety: Reading vs. Writing (Burning)
+
+Reading (Fetch) never modifies your ECM and is always safe. **Writing
+("burning") changes to the EEPROM can leave your ECM in a bad state if
+interrupted or done with mismatched data** — treat it with respect:
+
+- Burning is **disabled by default**. You must explicitly enable it under
+  **Settings → Enable EEPROM burning**, and the app shows an extra warning
+  dialog every time you burn.
+- Before writing, EcmDroid re-reads the ECM's ID/version and refuses to burn
+  if it doesn't match the EEPROM data you're about to write (protects against
+  writing one motorcycle's tune to a different ECM).
+- Don't disconnect, lose Bluetooth/BLE range, or let your phone sleep during
+  a burn. Enable **Keep screen on** in Settings for long sessions.
+- Keep a saved (`.xpr`) backup of the EEPROM *before* you start editing, so
+  you can always restore a known-good state.
+- **Optimized burning** (only write touched pages) is faster but only writes
+  pages you've actually changed; if you're unsure exactly what changed,
+  leaving it off (full-page burn) is the more conservative choice.
+
+## 11. Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Connect button never turns green | Wrong protocol selected (Stock vs. Factory Race) — try the other one. Wrong baud rate on a DIY adapter (9600 for Stock, 19200 for Factory Race). |
+| "No USB COM Devices available" | USB-serial adapter not recognized/plugged in, or your phone/OS doesn't support USB host mode. Check the adapter uses one of the supported chipsets (FTDI, CP210x, PL2303, CH340/CH341/CH9102, or a CDC-ACM device such as Arduino). |
+| "Give USB Permission" / connection fails after that prompt | Re-plug the adapter and accept the Android USB permission dialog when it appears. |
+| BLE device doesn't show up while scanning | On Android 6–11, BLE scanning requires system Location Services to be turned on. Turn on Location, or let the app fall back to classic discovery. Also confirm Bluetooth is enabled. |
+| Classic Bluetooth device not in the list | Pair it first in Android's own Settings → Bluetooth app, then reopen EcmDroid. |
+| Connected, but ECM Information fields stay blank/N/A | ECM took the version request but didn't answer as expected — usually a protocol/baud mismatch, or a loose diagnostic-connector cable. Reseat the connector and retry. |
+| Trouble reading/writing EEPROM mid-operation | Stay in range and keep the screen awake; retry the Fetch/Burn. If a Burn is refused with an ID-mismatch error, you loaded/prepared data for a different ECM than the one currently connected. |
+| Log file location not writable | Set/repick the storage folder in Settings before recording — the picker grants EcmDroid persistent access to that folder only. |
+
+## 12. Privacy
+
+See [`privacy-policy.md`](../privacy-policy.md) for the full policy. In short:
+EcmDroid does not collect or transmit any personal data; all ECM data,
+EEPROM dumps, and logs stay on your device and in the storage folder you
+choose.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md`: a repository guide for AI coding agents covering architecture, data flow, key directories, and conventions.
- Add `docs/USER_GUIDE.md`: installing, connecting, and using every screen in the app.
- Add `docs/DEVELOPER_GUIDE.md`: architecture, wire protocol, data model, and build/test instructions.
- Link both docs from `README.md`.

No code changes; documentation only.